### PR TITLE
Use anonymous keyword arguments forwarding

### DIFF
--- a/lib/ruby_npm/options/types.rb
+++ b/lib/ruby_npm/options/types.rb
@@ -6,8 +6,8 @@ require_relative 'types/flag'
 module RubyNPM
   module Options
     module Types
-      def self.standard(name, value, **opts)
-        Standard.new(name, value, **opts)
+      def self.standard(name, value, **)
+        Standard.new(name, value, **)
       end
 
       def self.flag(name, value)


### PR DESCRIPTION
Fixes two pre-existing `Style/ArgumentsForwarding` RuboCop offences in `lib/ruby_npm/options/types.rb` ("Use anonymous keyword arguments forwarding (`**`)").

This lint failure was blocking the `check` job on the GHA migration PR #103. RuboCop and the full RSpec suite (269 examples) pass on this branch.